### PR TITLE
[FIX] csv2xml: Error when the module with csv folder has __openerp__py file.

### DIFF
--- a/csv2xml/csv2xml.py
+++ b/csv2xml/csv2xml.py
@@ -452,7 +452,7 @@ def fix_module_name(path):
     manifest_file = os.path.join(path, '__manifest__.py')
     if os.path.exists(openerp_file) and os.path.isfile(openerp_file):
         pass
-    if os.path.exists(manifest_file) and os.path.isfile(manifest_file):
+    elif os.path.exists(manifest_file) and os.path.isfile(manifest_file):
         pass
     else:
         msg = ('The given module is not a openerp module. Missing'

--- a/csv2xml/csv2xml.py
+++ b/csv2xml/csv2xml.py
@@ -450,13 +450,12 @@ def fix_module_name(path):
     path = dir_full_path(path)
     openerp_file = os.path.join(path, '__openerp__.py')
     manifest_file = os.path.join(path, '__manifest__.py')
-    if os.path.exists(openerp_file) and os.path.isfile(openerp_file):
-        pass
-    elif os.path.exists(manifest_file) and os.path.isfile(manifest_file):
-        pass
-    else:
+    if not (os.path.exists(openerp_file) and
+            os.path.isfile(openerp_file)) and not \
+           (os.path.exists(manifest_file) and
+            os.path.isfile(manifest_file)):
         msg = ('The given module is not a openerp module. Missing'
-                ' __openerp__.py or __manifest__.py file.')
+               ' __openerp__.py or __manifest__.py file.')
         raise argparse.ArgumentTypeError(msg)
     return path
 


### PR DESCRIPTION
## Issue #2 

When the odoo's module has a `__openerp__.py` file, occurs a error because the if for check if the `__openerp__.py` file exists is fine, but, the next if checks again the `__manifest__.py` file and not should, because the `__openerp__.py` file already have been checked